### PR TITLE
Support disableIngressClassLookup, disableAPIResources

### DIFF
--- a/pkg/provider/kubernetes/crd/client-containous.go
+++ b/pkg/provider/kubernetes/crd/client-containous.go
@@ -320,49 +320,69 @@ func (c *clientWrapper) getContainousTraefikService(namespace, name string) (*tr
 	return toVersion.(*traefikv1alpha1.TraefikService), exist, err
 }
 
-func addContainousInformers(factoryCrd traefikinformers.SharedInformerFactory, eventHandler *k8s.ResourceEventHandler) error {
-	_, err := factoryCrd.TraefikContainous().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+func addContainousInformers(factoryCrd traefikinformers.SharedInformerFactory, eventHandler *k8s.ResourceEventHandler, DisableAPIResources []string) error {
+	var err error
+	if shouldProcessResource("IngressRoute", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().Middlewares().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("Middleware", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().Middlewares().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().MiddlewareTCPs().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("MiddlewareTCP", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().MiddlewareTCPs().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRouteTCPs().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
-	}
-	_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRouteUDPs().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("IngressRouteTCP", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRouteTCPs().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("IngressRouteUDP", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRouteUDPs().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().ServersTransports().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("TLSOption", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().TLSStores().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("ServersTransport", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().ServersTransports().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = factoryCrd.TraefikContainous().V1alpha1().TraefikServices().Informer().AddEventHandler(eventHandler)
-	if err != nil {
-		return err
+	if shouldProcessResource("TLSStore", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().TLSStores().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
+	}
+
+	if shouldProcessResource("TraefikService", DisableAPIResources) {
+		_, err = factoryCrd.TraefikContainous().V1alpha1().TraefikServices().Informer().AddEventHandler(eventHandler)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/provider/kubernetes/crd/client-containous.go
+++ b/pkg/provider/kubernetes/crd/client-containous.go
@@ -320,65 +320,65 @@ func (c *clientWrapper) getContainousTraefikService(namespace, name string) (*tr
 	return toVersion.(*traefikv1alpha1.TraefikService), exist, err
 }
 
-func addContainousInformers(factoryCrd traefikinformers.SharedInformerFactory, eventHandler *k8s.ResourceEventHandler, DisableAPIResources []string) error {
+func addContainousInformers(factoryCrd traefikinformers.SharedInformerFactory, eventHandler *k8s.ResourceEventHandler, disableAPIResources []string) error {
 	var err error
-	if shouldProcessResource("IngressRoute", DisableAPIResources) {
+	if shouldProcessResource("IngressRoute", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("Middleware", DisableAPIResources) {
+	if shouldProcessResource("Middleware", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().Middlewares().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("MiddlewareTCP", DisableAPIResources) {
+	if shouldProcessResource("MiddlewareTCP", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().MiddlewareTCPs().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("IngressRouteTCP", DisableAPIResources) {
+	if shouldProcessResource("IngressRouteTCP", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRouteTCPs().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("IngressRouteUDP", DisableAPIResources) {
+	if shouldProcessResource("IngressRouteUDP", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().IngressRouteUDPs().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("TLSOption", DisableAPIResources) {
+	if shouldProcessResource("TLSOption", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("ServersTransport", DisableAPIResources) {
+	if shouldProcessResource("ServersTransport", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().ServersTransports().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("TLSStore", DisableAPIResources) {
+	if shouldProcessResource("TLSStore", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().TLSStores().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err
 		}
 	}
 
-	if shouldProcessResource("TraefikService", DisableAPIResources) {
+	if shouldProcessResource("TraefikService", disableAPIResources) {
 		_, err = factoryCrd.TraefikContainous().V1alpha1().TraefikServices().Informer().AddEventHandler(eventHandler)
 		if err != nil {
 			return err

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -31,17 +31,17 @@ const resyncPeriod = 10 * time.Minute
 // WatchAll starts the watch of the Provider resources and updates the stores.
 // The stores can then be accessed via the Get* functions.
 type Client interface {
-	WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error)
-	GetIngressRoutes() []*traefikv1alpha1.IngressRoute
-	GetIngressRouteTCPs() []*traefikv1alpha1.IngressRouteTCP
-	GetIngressRouteUDPs() []*traefikv1alpha1.IngressRouteUDP
-	GetMiddlewares() []*traefikv1alpha1.Middleware
-	GetMiddlewareTCPs() []*traefikv1alpha1.MiddlewareTCP
-	GetTraefikService(namespace, name string) (*traefikv1alpha1.TraefikService, bool, error)
-	GetTraefikServices() []*traefikv1alpha1.TraefikService
-	GetTLSOptions() []*traefikv1alpha1.TLSOption
-	GetServersTransports() []*traefikv1alpha1.ServersTransport
-	GetTLSStores() []*traefikv1alpha1.TLSStore
+	WatchAll(namespaces []string, DisableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error)
+	GetIngressRoutes(DisableAPIResources []string) []*traefikv1alpha1.IngressRoute
+	GetIngressRouteTCPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP
+	GetIngressRouteUDPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP
+	GetMiddlewares(DisableAPIResources []string) []*traefikv1alpha1.Middleware
+	GetMiddlewareTCPs(DisableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP
+	GetTraefikService(namespace, name string, DisableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error)
+	GetTraefikServices(DisableAPIResources []string) []*traefikv1alpha1.TraefikService
+	GetTLSOptions(DisableAPIResources []string) []*traefikv1alpha1.TLSOption
+	GetServersTransports(DisableAPIResources []string) []*traefikv1alpha1.ServersTransport
+	GetTLSStores(DisableAPIResources []string) []*traefikv1alpha1.TLSStore
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
@@ -142,8 +142,17 @@ func newExternalClusterClient(endpoint, token, caFilePath string) (*clientWrappe
 	return createClientFromConfig(config)
 }
 
+func shouldProcessResource(resource string, DisableAPIResources []string) bool {
+	// TODO: Support toLower() for resource names
+	if slices.Contains(DisableAPIResources, resource) || slices.Contains(DisableAPIResources, "all") || slices.Contains(DisableAPIResources, resource+"s") {
+		log.Debugf("Skipping processing of %s resource", resource)
+		return false
+	}
+	return true
+}
+
 // WatchAll starts namespace-specific controllers for all relevant kinds.
-func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
+func (c *clientWrapper) WatchAll(namespaces []string, DisableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	eventCh := make(chan interface{}, 1)
 	eventHandler := &k8s.ResourceEventHandler{Ev: eventCh}
 
@@ -164,44 +173,63 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 
 	for _, ns := range namespaces {
 		factoryCrd := traefikinformers.NewSharedInformerFactoryWithOptions(c.csCrd, resyncPeriod, traefikinformers.WithNamespace(ns), traefikinformers.WithTweakListOptions(matchesLabelSelector))
-		_, err := factoryCrd.Traefik().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		var err error
+		if shouldProcessResource("IngressRoute", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().Middlewares().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("Middleware", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().Middlewares().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().MiddlewareTCPs().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("MiddlewareTCP", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().MiddlewareTCPs().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().IngressRouteTCPs().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("IngressRouteTCP", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().IngressRouteTCPs().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().IngressRouteUDPs().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("IngressRouteUDP", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().IngressRouteUDPs().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("TLSOption", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().ServersTransports().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("ServersTransport", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().ServersTransports().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().TLSStores().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("TLSStore", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().TLSStores().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
-		_, err = factoryCrd.Traefik().V1alpha1().TraefikServices().Informer().AddEventHandler(eventHandler)
-		if err != nil {
-			return nil, err
+		if shouldProcessResource("TraefikService", DisableAPIResources) {
+			_, err = factoryCrd.Traefik().V1alpha1().TraefikServices().Informer().AddEventHandler(eventHandler)
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		err = addContainousInformers(factoryCrd, eventHandler)
+		err = addContainousInformers(factoryCrd, eventHandler, DisableAPIResources)
 		if err != nil {
 			return nil, err
 		}
@@ -256,146 +284,168 @@ func (c *clientWrapper) WatchAll(namespaces []string, stopCh <-chan struct{}) (<
 	return eventCh, nil
 }
 
-func (c *clientWrapper) GetIngressRoutes() []*traefikv1alpha1.IngressRoute {
+func (c *clientWrapper) GetIngressRoutes(DisableAPIResources []string) []*traefikv1alpha1.IngressRoute {
 	var result []*traefikv1alpha1.IngressRoute
 
-	for ns, factory := range c.factoriesCrd {
-		ings, err := factory.Traefik().V1alpha1().IngressRoutes().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list ingress routes in namespace %s: %v", ns, err)
+	if shouldProcessResource("IngressRoute", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			ings, err := factory.Traefik().V1alpha1().IngressRoutes().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list ingress routes in namespace %s: %v", ns, err)
+			}
+			result = append(result, ings...)
 		}
-		result = append(result, ings...)
 	}
 
 	return c.appendContainousIngressRoutes(result)
 }
 
-func (c *clientWrapper) GetIngressRouteTCPs() []*traefikv1alpha1.IngressRouteTCP {
+func (c *clientWrapper) GetIngressRouteTCPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP {
 	var result []*traefikv1alpha1.IngressRouteTCP
 
-	for ns, factory := range c.factoriesCrd {
-		ings, err := factory.Traefik().V1alpha1().IngressRouteTCPs().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list tcp ingress routes in namespace %s: %v", ns, err)
+	if shouldProcessResource("IngressRouteTCP", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			ings, err := factory.Traefik().V1alpha1().IngressRouteTCPs().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list tcp ingress routes in namespace %s: %v", ns, err)
+			}
+			result = append(result, ings...)
 		}
-		result = append(result, ings...)
 	}
 
 	return c.appendContainousIngressRouteTCPs(result)
 }
 
-func (c *clientWrapper) GetIngressRouteUDPs() []*traefikv1alpha1.IngressRouteUDP {
+func (c *clientWrapper) GetIngressRouteUDPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP {
 	var result []*traefikv1alpha1.IngressRouteUDP
 
-	for ns, factory := range c.factoriesCrd {
-		ings, err := factory.Traefik().V1alpha1().IngressRouteUDPs().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list udp ingress routes in namespace %s: %v", ns, err)
+	if shouldProcessResource("IngressRouteUDP", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			ings, err := factory.Traefik().V1alpha1().IngressRouteUDPs().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list udp ingress routes in namespace %s: %v", ns, err)
+			}
+			result = append(result, ings...)
 		}
-		result = append(result, ings...)
 	}
 
 	return c.appendContainousIngressRouteUDPs(result)
 }
 
-func (c *clientWrapper) GetMiddlewares() []*traefikv1alpha1.Middleware {
+func (c *clientWrapper) GetMiddlewares(DisableAPIResources []string) []*traefikv1alpha1.Middleware {
 	var result []*traefikv1alpha1.Middleware
 
-	for ns, factory := range c.factoriesCrd {
-		middlewares, err := factory.Traefik().V1alpha1().Middlewares().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list middlewares in namespace %s: %v", ns, err)
+	if shouldProcessResource("Middleware", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			middlewares, err := factory.Traefik().V1alpha1().Middlewares().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list middlewares in namespace %s: %v", ns, err)
+			}
+			result = append(result, middlewares...)
 		}
-		result = append(result, middlewares...)
 	}
 
 	return c.appendContainousMiddlewares(result)
 }
 
-func (c *clientWrapper) GetMiddlewareTCPs() []*traefikv1alpha1.MiddlewareTCP {
+func (c *clientWrapper) GetMiddlewareTCPs(DisableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP {
 	var result []*traefikv1alpha1.MiddlewareTCP
 
-	for ns, factory := range c.factoriesCrd {
-		middlewares, err := factory.Traefik().V1alpha1().MiddlewareTCPs().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list TCP middlewares in namespace %s: %v", ns, err)
+	if shouldProcessResource("MiddlewareTCP", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			middlewares, err := factory.Traefik().V1alpha1().MiddlewareTCPs().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list TCP middlewares in namespace %s: %v", ns, err)
+			}
+			result = append(result, middlewares...)
 		}
-		result = append(result, middlewares...)
 	}
 
 	return c.appendContainousMiddlewareTCPs(result)
 }
 
 // GetTraefikService returns the named service from the given namespace.
-func (c *clientWrapper) GetTraefikService(namespace, name string) (*traefikv1alpha1.TraefikService, bool, error) {
+func (c *clientWrapper) GetTraefikService(namespace, name string, DisableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error) {
 	if !c.isWatchedNamespace(namespace) {
 		return nil, false, fmt.Errorf("failed to get service %s/%s: namespace is not within watched namespaces", namespace, name)
 	}
 
-	service, err := c.factoriesCrd[c.lookupNamespace(namespace)].Traefik().V1alpha1().TraefikServices().Lister().TraefikServices(namespace).Get(name)
-	exist, err := translateNotFoundError(err)
+	if shouldProcessResource("TraefikService", DisableAPIResources) {
+		service, err := c.factoriesCrd[c.lookupNamespace(namespace)].Traefik().V1alpha1().TraefikServices().Lister().TraefikServices(namespace).Get(name)
+		exist, err := translateNotFoundError(err)
 
-	if !exist {
-		return c.getContainousTraefikService(namespace, name)
+		if !exist {
+			return c.getContainousTraefikService(namespace, name)
+		}
+
+		return service, exist, err
+	} else {
+		return nil, false, nil
 	}
-
-	return service, exist, err
 }
 
-func (c *clientWrapper) GetTraefikServices() []*traefikv1alpha1.TraefikService {
+func (c *clientWrapper) GetTraefikServices(DisableAPIResources []string) []*traefikv1alpha1.TraefikService {
 	var result []*traefikv1alpha1.TraefikService
 
-	for ns, factory := range c.factoriesCrd {
-		traefikServices, err := factory.Traefik().V1alpha1().TraefikServices().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list Traefik services in namespace %s: %v", ns, err)
+	if shouldProcessResource("TraefikService", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			traefikServices, err := factory.Traefik().V1alpha1().TraefikServices().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list Traefik services in namespace %s: %v", ns, err)
+			}
+			result = append(result, traefikServices...)
 		}
-		result = append(result, traefikServices...)
 	}
 
 	return c.appendContainousTraefikServices(result)
 }
 
 // GetServersTransports returns all ServersTransport.
-func (c *clientWrapper) GetServersTransports() []*traefikv1alpha1.ServersTransport {
+func (c *clientWrapper) GetServersTransports(DisableAPIResources []string) []*traefikv1alpha1.ServersTransport {
 	var result []*traefikv1alpha1.ServersTransport
 
-	for ns, factory := range c.factoriesCrd {
-		serversTransports, err := factory.Traefik().V1alpha1().ServersTransports().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list servers transport in namespace %s: %v", ns, err)
+	if shouldProcessResource("ServersTransport", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			serversTransports, err := factory.Traefik().V1alpha1().ServersTransports().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list servers transport in namespace %s: %v", ns, err)
+			}
+			result = append(result, serversTransports...)
 		}
-		result = append(result, serversTransports...)
 	}
 
 	return c.appendContainousServersTransport(result)
 }
 
 // GetTLSOptions returns all TLS options.
-func (c *clientWrapper) GetTLSOptions() []*traefikv1alpha1.TLSOption {
+func (c *clientWrapper) GetTLSOptions(DisableAPIResources []string) []*traefikv1alpha1.TLSOption {
 	var result []*traefikv1alpha1.TLSOption
 
-	for ns, factory := range c.factoriesCrd {
-		options, err := factory.Traefik().V1alpha1().TLSOptions().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list tls options in namespace %s: %v", ns, err)
+	if shouldProcessResource("TLSOption", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			options, err := factory.Traefik().V1alpha1().TLSOptions().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list tls options in namespace %s: %v", ns, err)
+			}
+			result = append(result, options...)
 		}
-		result = append(result, options...)
 	}
 
 	return c.appendContainousTLSOptions(result)
 }
 
 // GetTLSStores returns all TLS stores.
-func (c *clientWrapper) GetTLSStores() []*traefikv1alpha1.TLSStore {
+func (c *clientWrapper) GetTLSStores(DisableAPIResources []string) []*traefikv1alpha1.TLSStore {
 	var result []*traefikv1alpha1.TLSStore
 
-	for ns, factory := range c.factoriesCrd {
-		stores, err := factory.Traefik().V1alpha1().TLSStores().Lister().List(labels.Everything())
-		if err != nil {
-			log.Errorf("Failed to list tls stores in namespace %s: %v", ns, err)
+	if shouldProcessResource("TLSStore", DisableAPIResources) {
+		for ns, factory := range c.factoriesCrd {
+			stores, err := factory.Traefik().V1alpha1().TLSStores().Lister().List(labels.Everything())
+			if err != nil {
+				log.Errorf("Failed to list tls stores in namespace %s: %v", ns, err)
+			}
+			result = append(result, stores...)
 		}
-		result = append(result, stores...)
 	}
 
 	return c.appendContainousTLSStores(result)

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -31,17 +31,17 @@ const resyncPeriod = 10 * time.Minute
 // WatchAll starts the watch of the Provider resources and updates the stores.
 // The stores can then be accessed via the Get* functions.
 type Client interface {
-	WatchAll(namespaces []string, DisableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error)
-	GetIngressRoutes(DisableAPIResources []string) []*traefikv1alpha1.IngressRoute
-	GetIngressRouteTCPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP
-	GetIngressRouteUDPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP
-	GetMiddlewares(DisableAPIResources []string) []*traefikv1alpha1.Middleware
-	GetMiddlewareTCPs(DisableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP
-	GetTraefikService(namespace, name string, DisableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error)
-	GetTraefikServices(DisableAPIResources []string) []*traefikv1alpha1.TraefikService
-	GetTLSOptions(DisableAPIResources []string) []*traefikv1alpha1.TLSOption
-	GetServersTransports(DisableAPIResources []string) []*traefikv1alpha1.ServersTransport
-	GetTLSStores(DisableAPIResources []string) []*traefikv1alpha1.TLSStore
+	WatchAll(namespaces []string, disableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error)
+	GetIngressRoutes(disableAPIResources []string) []*traefikv1alpha1.IngressRoute
+	GetIngressRouteTCPs(disableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP
+	GetIngressRouteUDPs(disableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP
+	GetMiddlewares(disableAPIResources []string) []*traefikv1alpha1.Middleware
+	GetMiddlewareTCPs(disableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP
+	GetTraefikService(namespace, name string, disableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error)
+	GetTraefikServices(disableAPIResources []string) []*traefikv1alpha1.TraefikService
+	GetTLSOptions(disableAPIResources []string) []*traefikv1alpha1.TLSOption
+	GetServersTransports(disableAPIResources []string) []*traefikv1alpha1.ServersTransport
+	GetTLSStores(disableAPIResources []string) []*traefikv1alpha1.TLSStore
 	GetService(namespace, name string) (*corev1.Service, bool, error)
 	GetSecret(namespace, name string) (*corev1.Secret, bool, error)
 	GetEndpoints(namespace, name string) (*corev1.Endpoints, bool, error)
@@ -142,9 +142,9 @@ func newExternalClusterClient(endpoint, token, caFilePath string) (*clientWrappe
 	return createClientFromConfig(config)
 }
 
-func shouldProcessResource(resource string, DisableAPIResources []string) bool {
+func shouldProcessResource(resource string, disableAPIResources []string) bool {
 	// TODO: Support toLower() for resource names
-	if slices.Contains(DisableAPIResources, resource) || slices.Contains(DisableAPIResources, "all") || slices.Contains(DisableAPIResources, resource+"s") {
+	if slices.Contains(disableAPIResources, resource) || slices.Contains(disableAPIResources, "all") || slices.Contains(disableAPIResources, resource+"s") {
 		log.Debugf("Skipping processing of %s resource", resource)
 		return false
 	}
@@ -152,7 +152,7 @@ func shouldProcessResource(resource string, DisableAPIResources []string) bool {
 }
 
 // WatchAll starts namespace-specific controllers for all relevant kinds.
-func (c *clientWrapper) WatchAll(namespaces []string, DisableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
+func (c *clientWrapper) WatchAll(namespaces []string, disableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	eventCh := make(chan interface{}, 1)
 	eventHandler := &k8s.ResourceEventHandler{Ev: eventCh}
 
@@ -174,62 +174,62 @@ func (c *clientWrapper) WatchAll(namespaces []string, DisableAPIResources []stri
 	for _, ns := range namespaces {
 		factoryCrd := traefikinformers.NewSharedInformerFactoryWithOptions(c.csCrd, resyncPeriod, traefikinformers.WithNamespace(ns), traefikinformers.WithTweakListOptions(matchesLabelSelector))
 		var err error
-		if shouldProcessResource("IngressRoute", DisableAPIResources) {
+		if shouldProcessResource("IngressRoute", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().IngressRoutes().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("Middleware", DisableAPIResources) {
+		if shouldProcessResource("Middleware", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().Middlewares().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("MiddlewareTCP", DisableAPIResources) {
+		if shouldProcessResource("MiddlewareTCP", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().MiddlewareTCPs().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("IngressRouteTCP", DisableAPIResources) {
+		if shouldProcessResource("IngressRouteTCP", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().IngressRouteTCPs().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("IngressRouteUDP", DisableAPIResources) {
+		if shouldProcessResource("IngressRouteUDP", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().IngressRouteUDPs().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("TLSOption", DisableAPIResources) {
+		if shouldProcessResource("TLSOption", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().TLSOptions().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("ServersTransport", DisableAPIResources) {
+		if shouldProcessResource("ServersTransport", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().ServersTransports().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("TLSStore", DisableAPIResources) {
+		if shouldProcessResource("TLSStore", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().TLSStores().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
-		if shouldProcessResource("TraefikService", DisableAPIResources) {
+		if shouldProcessResource("TraefikService", disableAPIResources) {
 			_, err = factoryCrd.Traefik().V1alpha1().TraefikServices().Informer().AddEventHandler(eventHandler)
 			if err != nil {
 				return nil, err
 			}
 		}
 
-		err = addContainousInformers(factoryCrd, eventHandler, DisableAPIResources)
+		err = addContainousInformers(factoryCrd, eventHandler, disableAPIResources)
 		if err != nil {
 			return nil, err
 		}
@@ -284,10 +284,10 @@ func (c *clientWrapper) WatchAll(namespaces []string, DisableAPIResources []stri
 	return eventCh, nil
 }
 
-func (c *clientWrapper) GetIngressRoutes(DisableAPIResources []string) []*traefikv1alpha1.IngressRoute {
+func (c *clientWrapper) GetIngressRoutes(disableAPIResources []string) []*traefikv1alpha1.IngressRoute {
 	var result []*traefikv1alpha1.IngressRoute
 
-	if shouldProcessResource("IngressRoute", DisableAPIResources) {
+	if shouldProcessResource("IngressRoute", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			ings, err := factory.Traefik().V1alpha1().IngressRoutes().Lister().List(labels.Everything())
 			if err != nil {
@@ -300,10 +300,10 @@ func (c *clientWrapper) GetIngressRoutes(DisableAPIResources []string) []*traefi
 	return c.appendContainousIngressRoutes(result)
 }
 
-func (c *clientWrapper) GetIngressRouteTCPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP {
+func (c *clientWrapper) GetIngressRouteTCPs(disableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP {
 	var result []*traefikv1alpha1.IngressRouteTCP
 
-	if shouldProcessResource("IngressRouteTCP", DisableAPIResources) {
+	if shouldProcessResource("IngressRouteTCP", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			ings, err := factory.Traefik().V1alpha1().IngressRouteTCPs().Lister().List(labels.Everything())
 			if err != nil {
@@ -316,10 +316,10 @@ func (c *clientWrapper) GetIngressRouteTCPs(DisableAPIResources []string) []*tra
 	return c.appendContainousIngressRouteTCPs(result)
 }
 
-func (c *clientWrapper) GetIngressRouteUDPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP {
+func (c *clientWrapper) GetIngressRouteUDPs(disableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP {
 	var result []*traefikv1alpha1.IngressRouteUDP
 
-	if shouldProcessResource("IngressRouteUDP", DisableAPIResources) {
+	if shouldProcessResource("IngressRouteUDP", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			ings, err := factory.Traefik().V1alpha1().IngressRouteUDPs().Lister().List(labels.Everything())
 			if err != nil {
@@ -332,10 +332,10 @@ func (c *clientWrapper) GetIngressRouteUDPs(DisableAPIResources []string) []*tra
 	return c.appendContainousIngressRouteUDPs(result)
 }
 
-func (c *clientWrapper) GetMiddlewares(DisableAPIResources []string) []*traefikv1alpha1.Middleware {
+func (c *clientWrapper) GetMiddlewares(disableAPIResources []string) []*traefikv1alpha1.Middleware {
 	var result []*traefikv1alpha1.Middleware
 
-	if shouldProcessResource("Middleware", DisableAPIResources) {
+	if shouldProcessResource("Middleware", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			middlewares, err := factory.Traefik().V1alpha1().Middlewares().Lister().List(labels.Everything())
 			if err != nil {
@@ -348,10 +348,10 @@ func (c *clientWrapper) GetMiddlewares(DisableAPIResources []string) []*traefikv
 	return c.appendContainousMiddlewares(result)
 }
 
-func (c *clientWrapper) GetMiddlewareTCPs(DisableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP {
+func (c *clientWrapper) GetMiddlewareTCPs(disableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP {
 	var result []*traefikv1alpha1.MiddlewareTCP
 
-	if shouldProcessResource("MiddlewareTCP", DisableAPIResources) {
+	if shouldProcessResource("MiddlewareTCP", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			middlewares, err := factory.Traefik().V1alpha1().MiddlewareTCPs().Lister().List(labels.Everything())
 			if err != nil {
@@ -365,12 +365,12 @@ func (c *clientWrapper) GetMiddlewareTCPs(DisableAPIResources []string) []*traef
 }
 
 // GetTraefikService returns the named service from the given namespace.
-func (c *clientWrapper) GetTraefikService(namespace, name string, DisableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error) {
+func (c *clientWrapper) GetTraefikService(namespace, name string, disableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error) {
 	if !c.isWatchedNamespace(namespace) {
 		return nil, false, fmt.Errorf("failed to get service %s/%s: namespace is not within watched namespaces", namespace, name)
 	}
 
-	if shouldProcessResource("TraefikService", DisableAPIResources) {
+	if shouldProcessResource("TraefikService", disableAPIResources) {
 		service, err := c.factoriesCrd[c.lookupNamespace(namespace)].Traefik().V1alpha1().TraefikServices().Lister().TraefikServices(namespace).Get(name)
 		exist, err := translateNotFoundError(err)
 
@@ -384,10 +384,10 @@ func (c *clientWrapper) GetTraefikService(namespace, name string, DisableAPIReso
 	}
 }
 
-func (c *clientWrapper) GetTraefikServices(DisableAPIResources []string) []*traefikv1alpha1.TraefikService {
+func (c *clientWrapper) GetTraefikServices(disableAPIResources []string) []*traefikv1alpha1.TraefikService {
 	var result []*traefikv1alpha1.TraefikService
 
-	if shouldProcessResource("TraefikService", DisableAPIResources) {
+	if shouldProcessResource("TraefikService", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			traefikServices, err := factory.Traefik().V1alpha1().TraefikServices().Lister().List(labels.Everything())
 			if err != nil {
@@ -401,10 +401,10 @@ func (c *clientWrapper) GetTraefikServices(DisableAPIResources []string) []*trae
 }
 
 // GetServersTransports returns all ServersTransport.
-func (c *clientWrapper) GetServersTransports(DisableAPIResources []string) []*traefikv1alpha1.ServersTransport {
+func (c *clientWrapper) GetServersTransports(disableAPIResources []string) []*traefikv1alpha1.ServersTransport {
 	var result []*traefikv1alpha1.ServersTransport
 
-	if shouldProcessResource("ServersTransport", DisableAPIResources) {
+	if shouldProcessResource("ServersTransport", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			serversTransports, err := factory.Traefik().V1alpha1().ServersTransports().Lister().List(labels.Everything())
 			if err != nil {
@@ -418,10 +418,10 @@ func (c *clientWrapper) GetServersTransports(DisableAPIResources []string) []*tr
 }
 
 // GetTLSOptions returns all TLS options.
-func (c *clientWrapper) GetTLSOptions(DisableAPIResources []string) []*traefikv1alpha1.TLSOption {
+func (c *clientWrapper) GetTLSOptions(disableAPIResources []string) []*traefikv1alpha1.TLSOption {
 	var result []*traefikv1alpha1.TLSOption
 
-	if shouldProcessResource("TLSOption", DisableAPIResources) {
+	if shouldProcessResource("TLSOption", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			options, err := factory.Traefik().V1alpha1().TLSOptions().Lister().List(labels.Everything())
 			if err != nil {
@@ -435,10 +435,10 @@ func (c *clientWrapper) GetTLSOptions(DisableAPIResources []string) []*traefikv1
 }
 
 // GetTLSStores returns all TLS stores.
-func (c *clientWrapper) GetTLSStores(DisableAPIResources []string) []*traefikv1alpha1.TLSStore {
+func (c *clientWrapper) GetTLSStores(disableAPIResources []string) []*traefikv1alpha1.TLSStore {
 	var result []*traefikv1alpha1.TLSStore
 
-	if shouldProcessResource("TLSStore", DisableAPIResources) {
+	if shouldProcessResource("TLSStore", disableAPIResources) {
 		for ns, factory := range c.factoriesCrd {
 			stores, err := factory.Traefik().V1alpha1().TLSStores().Lister().List(labels.Everything())
 			if err != nil {

--- a/pkg/provider/kubernetes/crd/client.go
+++ b/pkg/provider/kubernetes/crd/client.go
@@ -379,9 +379,9 @@ func (c *clientWrapper) GetTraefikService(namespace, name string, disableAPIReso
 		}
 
 		return service, exist, err
-	} else {
-		return nil, false, nil
 	}
+
+	return nil, false, nil
 }
 
 func (c *clientWrapper) GetTraefikServices(disableAPIResources []string) []*traefikv1alpha1.TraefikService {

--- a/pkg/provider/kubernetes/crd/client_mock_test.go
+++ b/pkg/provider/kubernetes/crd/client_mock_test.go
@@ -88,27 +88,27 @@ func newClientMock(paths ...string) clientMock {
 	return c
 }
 
-func (c clientMock) GetIngressRoutes(DisableAPIResources []string) []*traefikv1alpha1.IngressRoute {
+func (c clientMock) GetIngressRoutes(disableAPIResources []string) []*traefikv1alpha1.IngressRoute {
 	return c.ingressRoutes
 }
 
-func (c clientMock) GetIngressRouteTCPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP {
+func (c clientMock) GetIngressRouteTCPs(disableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP {
 	return c.ingressRouteTCPs
 }
 
-func (c clientMock) GetIngressRouteUDPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP {
+func (c clientMock) GetIngressRouteUDPs(disableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP {
 	return c.ingressRouteUDPs
 }
 
-func (c clientMock) GetMiddlewares(DisableAPIResources []string) []*traefikv1alpha1.Middleware {
+func (c clientMock) GetMiddlewares(disableAPIResources []string) []*traefikv1alpha1.Middleware {
 	return c.middlewares
 }
 
-func (c clientMock) GetMiddlewareTCPs(DisableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP {
+func (c clientMock) GetMiddlewareTCPs(disableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP {
 	return c.middlewareTCPs
 }
 
-func (c clientMock) GetTraefikService(namespace, name string, DisableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error) {
+func (c clientMock) GetTraefikService(namespace, name string, disableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error) {
 	for _, svc := range c.traefikServices {
 		if svc.Namespace == namespace && svc.Name == name {
 			return svc, true, nil
@@ -118,19 +118,19 @@ func (c clientMock) GetTraefikService(namespace, name string, DisableAPIResource
 	return nil, false, nil
 }
 
-func (c clientMock) GetTraefikServices(DisableAPIResources []string) []*traefikv1alpha1.TraefikService {
+func (c clientMock) GetTraefikServices(disableAPIResources []string) []*traefikv1alpha1.TraefikService {
 	return c.traefikServices
 }
 
-func (c clientMock) GetTLSOptions(DisableAPIResources []string) []*traefikv1alpha1.TLSOption {
+func (c clientMock) GetTLSOptions(disableAPIResources []string) []*traefikv1alpha1.TLSOption {
 	return c.tlsOptions
 }
 
-func (c clientMock) GetTLSStores(DisableAPIResources []string) []*traefikv1alpha1.TLSStore {
+func (c clientMock) GetTLSStores(disableAPIResources []string) []*traefikv1alpha1.TLSStore {
 	return c.tlsStores
 }
 
-func (c clientMock) GetServersTransports(DisableAPIResources []string) []*traefikv1alpha1.ServersTransport {
+func (c clientMock) GetServersTransports(disableAPIResources []string) []*traefikv1alpha1.ServersTransport {
 	return c.serversTransport
 }
 
@@ -184,6 +184,6 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 	return nil, false, nil
 }
 
-func (c clientMock) WatchAll(namespaces []string, DisableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
+func (c clientMock) WatchAll(namespaces []string, disableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
 }

--- a/pkg/provider/kubernetes/crd/client_mock_test.go
+++ b/pkg/provider/kubernetes/crd/client_mock_test.go
@@ -88,27 +88,27 @@ func newClientMock(paths ...string) clientMock {
 	return c
 }
 
-func (c clientMock) GetIngressRoutes() []*traefikv1alpha1.IngressRoute {
+func (c clientMock) GetIngressRoutes(DisableAPIResources []string) []*traefikv1alpha1.IngressRoute {
 	return c.ingressRoutes
 }
 
-func (c clientMock) GetIngressRouteTCPs() []*traefikv1alpha1.IngressRouteTCP {
+func (c clientMock) GetIngressRouteTCPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteTCP {
 	return c.ingressRouteTCPs
 }
 
-func (c clientMock) GetIngressRouteUDPs() []*traefikv1alpha1.IngressRouteUDP {
+func (c clientMock) GetIngressRouteUDPs(DisableAPIResources []string) []*traefikv1alpha1.IngressRouteUDP {
 	return c.ingressRouteUDPs
 }
 
-func (c clientMock) GetMiddlewares() []*traefikv1alpha1.Middleware {
+func (c clientMock) GetMiddlewares(DisableAPIResources []string) []*traefikv1alpha1.Middleware {
 	return c.middlewares
 }
 
-func (c clientMock) GetMiddlewareTCPs() []*traefikv1alpha1.MiddlewareTCP {
+func (c clientMock) GetMiddlewareTCPs(DisableAPIResources []string) []*traefikv1alpha1.MiddlewareTCP {
 	return c.middlewareTCPs
 }
 
-func (c clientMock) GetTraefikService(namespace, name string) (*traefikv1alpha1.TraefikService, bool, error) {
+func (c clientMock) GetTraefikService(namespace, name string, DisableAPIResources []string) (*traefikv1alpha1.TraefikService, bool, error) {
 	for _, svc := range c.traefikServices {
 		if svc.Namespace == namespace && svc.Name == name {
 			return svc, true, nil
@@ -118,19 +118,19 @@ func (c clientMock) GetTraefikService(namespace, name string) (*traefikv1alpha1.
 	return nil, false, nil
 }
 
-func (c clientMock) GetTraefikServices() []*traefikv1alpha1.TraefikService {
+func (c clientMock) GetTraefikServices(DisableAPIResources []string) []*traefikv1alpha1.TraefikService {
 	return c.traefikServices
 }
 
-func (c clientMock) GetTLSOptions() []*traefikv1alpha1.TLSOption {
+func (c clientMock) GetTLSOptions(DisableAPIResources []string) []*traefikv1alpha1.TLSOption {
 	return c.tlsOptions
 }
 
-func (c clientMock) GetTLSStores() []*traefikv1alpha1.TLSStore {
+func (c clientMock) GetTLSStores(DisableAPIResources []string) []*traefikv1alpha1.TLSStore {
 	return c.tlsStores
 }
 
-func (c clientMock) GetServersTransports() []*traefikv1alpha1.ServersTransport {
+func (c clientMock) GetServersTransports(DisableAPIResources []string) []*traefikv1alpha1.ServersTransport {
 	return c.serversTransport
 }
 
@@ -184,6 +184,6 @@ func (c clientMock) GetSecret(namespace, name string) (*corev1.Secret, bool, err
 	return nil, false, nil
 }
 
-func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
+func (c clientMock) WatchAll(namespaces []string, DisableAPIResources []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
 }

--- a/pkg/provider/kubernetes/crd/client_test.go
+++ b/pkg/provider/kubernetes/crd/client_test.go
@@ -36,7 +36,7 @@ func TestClientIgnoresHelmOwnedSecrets(t *testing.T) {
 
 	stopCh := make(chan struct{})
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(nil, []string{}, stopCh)
 	require.NoError(t, err)
 
 	select {

--- a/pkg/provider/kubernetes/crd/kubernetes_http.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_http.go
@@ -31,7 +31,7 @@ func (p *Provider) loadIngressRouteConfiguration(ctx context.Context, client Cli
 		ServersTransports: map[string]*dynamic.ServersTransport{},
 	}
 
-	for _, ingressRoute := range client.GetIngressRoutes() {
+	for _, ingressRoute := range client.GetIngressRoutes(p.DisableAPIResources) {
 		ctxRt := log.With(ctx, log.Str("ingress", ingressRoute.Name), log.Str("namespace", ingressRoute.Namespace))
 		logger := log.FromContext(ctxRt)
 

--- a/pkg/provider/kubernetes/crd/kubernetes_tcp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_tcp.go
@@ -23,7 +23,7 @@ func (p *Provider) loadIngressRouteTCPConfiguration(ctx context.Context, client 
 		Services:    map[string]*dynamic.TCPService{},
 	}
 
-	for _, ingressRouteTCP := range client.GetIngressRouteTCPs() {
+	for _, ingressRouteTCP := range client.GetIngressRouteTCPs(p.DisableAPIResources) {
 		logger := log.FromContext(log.With(ctx, log.Str("ingress", ingressRouteTCP.Name), log.Str("namespace", ingressRouteTCP.Namespace)))
 
 		if !shouldProcessIngress(p.IngressClass, ingressRouteTCP.Annotations[annotationKubernetesIngressClass]) {

--- a/pkg/provider/kubernetes/crd/kubernetes_test.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_test.go
@@ -6089,7 +6089,7 @@ func TestCrossNamespace(t *testing.T) {
 
 			stopCh := make(chan struct{})
 
-			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, stopCh)
+			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, []string{}, stopCh)
 			require.NoError(t, err)
 
 			if k8sObjects != nil || crdObjects != nil {
@@ -6378,7 +6378,7 @@ func TestExternalNameService(t *testing.T) {
 
 			stopCh := make(chan struct{})
 
-			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, stopCh)
+			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, []string{}, stopCh)
 			require.NoError(t, err)
 
 			if k8sObjects != nil || crdObjects != nil {
@@ -6584,7 +6584,7 @@ func TestNativeLB(t *testing.T) {
 
 			stopCh := make(chan struct{})
 
-			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, stopCh)
+			eventCh, err := client.WatchAll([]string{"default", "cross-ns"}, []string{}, stopCh)
 			require.NoError(t, err)
 
 			if k8sObjects != nil || crdObjects != nil {
@@ -6623,7 +6623,7 @@ func TestCreateBasicAuthCredentials(t *testing.T) {
 
 	stopCh := make(chan struct{})
 
-	eventCh, err := client.WatchAll([]string{"default"}, stopCh)
+	eventCh, err := client.WatchAll([]string{"default"}, []string{}, stopCh)
 	require.NoError(t, err)
 
 	if k8sObjects != nil {

--- a/pkg/provider/kubernetes/crd/kubernetes_udp.go
+++ b/pkg/provider/kubernetes/crd/kubernetes_udp.go
@@ -19,7 +19,7 @@ func (p *Provider) loadIngressRouteUDPConfiguration(ctx context.Context, client 
 		Services: map[string]*dynamic.UDPService{},
 	}
 
-	for _, ingressRouteUDP := range client.GetIngressRouteUDPs() {
+	for _, ingressRouteUDP := range client.GetIngressRouteUDPs(p.DisableAPIResources) {
 		logger := log.FromContext(log.With(ctx, log.Str("ingress", ingressRouteUDP.Name), log.Str("namespace", ingressRouteUDP.Namespace)))
 
 		if !shouldProcessIngress(p.IngressClass, ingressRouteUDP.Annotations[annotationKubernetesIngressClass]) {

--- a/pkg/provider/kubernetes/ingress/client_mock_test.go
+++ b/pkg/provider/kubernetes/ingress/client_mock_test.go
@@ -128,7 +128,7 @@ func (c clientMock) GetIngressClasses() ([]*netv1.IngressClass, error) {
 	return c.ingressClasses, nil
 }
 
-func (c clientMock) WatchAll(namespaces []string, stopCh <-chan struct{}) (<-chan interface{}, error) {
+func (c clientMock) WatchAll(namespaces []string, disableIngressClassLookup bool, stopCh <-chan struct{}) (<-chan interface{}, error) {
 	return c.watchChan, nil
 }
 

--- a/pkg/provider/kubernetes/ingress/client_test.go
+++ b/pkg/provider/kubernetes/ingress/client_test.go
@@ -161,7 +161,7 @@ func TestClientIgnoresHelmOwnedSecrets(t *testing.T) {
 
 	stopCh := make(chan struct{})
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(nil, false, stopCh)
 	require.NoError(t, err)
 
 	select {
@@ -230,7 +230,7 @@ func TestClientIgnoresEmptyEndpointUpdates(t *testing.T) {
 
 	stopCh := make(chan struct{})
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(nil, false, stopCh)
 	require.NoError(t, err)
 
 	select {
@@ -314,7 +314,7 @@ func TestClientUsesCorrectServerVersion(t *testing.T) {
 
 	client := newClientImpl(kubeClient)
 
-	eventCh, err := client.WatchAll(nil, stopCh)
+	eventCh, err := client.WatchAll(nil, false, stopCh)
 	require.NoError(t, err)
 
 	select {
@@ -337,7 +337,7 @@ func TestClientUsesCorrectServerVersion(t *testing.T) {
 		GitVersion: "v1.19",
 	}
 
-	eventCh, err = client.WatchAll(nil, stopCh)
+	eventCh, err = client.WatchAll(nil, false, stopCh)
 	require.NoError(t, err)
 
 	select {

--- a/pkg/provider/kubernetes/ingress/kubernetes.go
+++ b/pkg/provider/kubernetes/ingress/kubernetes.go
@@ -48,6 +48,7 @@ type Provider struct {
 	ThrottleDuration          ptypes.Duration  `description:"Ingress refresh throttle duration" json:"throttleDuration,omitempty" toml:"throttleDuration,omitempty" yaml:"throttleDuration,omitempty" export:"true"`
 	AllowEmptyServices        bool             `description:"Allow creation of services without endpoints." json:"allowEmptyServices,omitempty" toml:"allowEmptyServices,omitempty" yaml:"allowEmptyServices,omitempty" export:"true"`
 	AllowExternalNameServices bool             `description:"Allow ExternalName services." json:"allowExternalNameServices,omitempty" toml:"allowExternalNameServices,omitempty" yaml:"allowExternalNameServices,omitempty" export:"true"`
+	DisableIngressClassLookup bool             `description:"Disable lookup of cluster-scoped IngressClass resources." json:"disableIngressClassLookup,omitempty" toml:"disableIngressClassLookup,omitempty" yaml:"disableIngressClassLookup,omitempty" export:"true"`
 
 	lastConfiguration safe.Safe
 
@@ -134,7 +135,7 @@ func (p *Provider) Provide(configurationChan chan<- dynamic.Message, pool *safe.
 
 	pool.GoCtx(func(ctxPool context.Context) {
 		operation := func() error {
-			eventsChan, err := k8sClient.WatchAll(p.Namespaces, ctxPool.Done())
+			eventsChan, err := k8sClient.WatchAll(p.Namespaces, p.DisableIngressClassLookup, ctxPool.Done())
 			if err != nil {
 				logger.Errorf("Error watching kubernetes events: %v", err)
 				timer := time.NewTimer(1 * time.Second)
@@ -213,7 +214,7 @@ func (p *Provider) loadConfigurationFromIngresses(ctx context.Context, client Cl
 
 	var ingressClasses []*netv1.IngressClass
 
-	if supportsIngressClass(serverVersion) {
+	if (supportsIngressClass(serverVersion)) && (!p.DisableIngressClassLookup) {
 		ics, err := client.GetIngressClasses()
 		if err != nil {
 			log.FromContext(ctx).Warnf("Failed to list ingress classes: %v", err)


### PR DESCRIPTION
This PR based on the upstream v2.11 branch adds support for the following: 

- Add support for toggling off `IngressClass` `get`/`list`/`watch`. This allows use of namespace scoped Ingress Controller in the v2.x branch - this is currently only supported in the V3.x branch upstream
- Add support for toggling off specific Traefik CR `get`/`list`/`watch`  in both `traefik.containo.us` and `traefik.io` API groups. This allows reconciliation restriction of specific CRs to more finely scope RBAC. 